### PR TITLE
add GetAll queries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Amplience"]
+}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 GO SDK for [Amplience](https://amplience.com/).
 
+## Development
 
-## Example
+To test the API, it might be useful to create a `main.go` file with your own Amplience credentials.
 
 ```go
 package main
@@ -41,7 +42,12 @@ func main() {
 }
 ```
 
+Then you can run your test code like so:
+
+```
+go run main.go
+```
 
 ## Contributing
 
-The Amplience specifications can be found at https://amplience.com/docs/api/dynamic-content/management/
+The Amplience specifications can be found at https://amplience.com/developers/docs/apis/content-management-reference/

--- a/content/content_repository.go
+++ b/content/content_repository.go
@@ -97,10 +97,30 @@ func (client *Client) ContentRepositoryUpdate(current ContentRepository, input C
 	return result, err
 }
 
-func (client *Client) ContentRepositoryList(hubID string) (ContentRepositoryResults, error) {
+func (client *Client) ContentRepositoryList(hubID string, parameters PaginationParameters) (ContentRepositoryResults, error) {
 	result := ContentRepositoryResults{}
-	endpoint := fmt.Sprintf("/hubs/%s/content-repositories", hubID)
+	endpoint := fmt.Sprintf("/hubs/%s/content-repositories?%s", hubID, PaginationQueryString(parameters))
 	err := client.request(http.MethodGet, endpoint, nil, &result)
+	return result, err
+}
+
+func (client *Client) ContentRepositoryGetAll(hubID string) ([]ContentRepository, error) {
+	parameters := PaginationParameters{}
+
+	response, err := client.ContentRepositoryList(hubID, parameters)
+
+	var result []ContentRepository
+	result = append(result, response.Items...)
+
+	for parameters.Page < response.Page.TotalPages-1 {
+		parameters.Page++
+		response, err := client.ContentRepositoryList(hubID, parameters)
+		if err != nil {
+			break
+		}
+		result = append(result, response.Items...)
+	}
+
 	return result, err
 }
 

--- a/content/content_type_schema.go
+++ b/content/content_type_schema.go
@@ -91,11 +91,33 @@ func (client *Client) ContentTypeSchemaUpdate(current ContentTypeSchema, update 
 	return result, err
 }
 
-func (client *Client) ContentTypeSchemaList(hubID string) (ContentTypeSchemaResults, error) {
+func (client *Client) ContentTypeSchemaList(hubID string, parameters StatusPaginationParameters) (ContentTypeSchemaResults, error) {
 	result := ContentTypeSchemaResults{}
-	endpoint := fmt.Sprintf("/hubs/%s/content-type-schemas", hubID)
+
+	endpoint := fmt.Sprintf("/hubs/%s/content-type-schemas?%s", hubID, StatusPaginationQueryString(parameters))
 
 	err := client.request(http.MethodGet, endpoint, nil, &result)
+	return result, err
+}
+
+func (client *Client) ContentTypeSchemaGetAll(hubID string, status ContentStatus) ([]ContentTypeSchema, error) {
+	parameters := StatusPaginationParameters{}
+	parameters.Status = status
+
+	response, err := client.ContentTypeSchemaList(hubID, parameters)
+
+	var result []ContentTypeSchema
+	result = append(result, response.Items...)
+
+	for parameters.Page < response.Page.TotalPages-1 {
+		parameters.Page++
+		response, err := client.ContentTypeSchemaList(hubID, parameters)
+		if err != nil {
+			break
+		}
+		result = append(result, response.Items...)
+	}
+
 	return result, err
 }
 

--- a/content/folder.go
+++ b/content/folder.go
@@ -66,10 +66,30 @@ func (client *Client) FolderDelete(id string) (Folder, error) {
 	return result, err
 }
 
-func (client *Client) FolderList(repositoryID string) (FolderResults, error) {
+func (client *Client) FolderList(repositoryID string, parameters PaginationParameters) (FolderResults, error) {
 	result := FolderResults{}
-	endpoint := fmt.Sprintf("/content-repositories/%s/folders", repositoryID)
+	endpoint := fmt.Sprintf("/content-repositories/%s/folders?%s", repositoryID, PaginationQueryString(parameters))
 
 	err := client.request(http.MethodGet, endpoint, nil, &result)
+	return result, err
+}
+
+func (client *Client) FolderGetAll(hubID string) ([]Folder, error) {
+	parameters := PaginationParameters{}
+
+	response, err := client.FolderList(hubID, parameters)
+
+	var result []Folder
+	result = append(result, response.Items...)
+
+	for parameters.Page < response.Page.TotalPages-1 {
+		parameters.Page++
+		response, err := client.FolderList(hubID, parameters)
+		if err != nil {
+			break
+		}
+		result = append(result, response.Items...)
+	}
+
 	return result, err
 }

--- a/content/pagination.go
+++ b/content/pagination.go
@@ -1,0 +1,104 @@
+package content
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type PaginationParameters struct {
+	Page int
+	Size int
+	Sort string
+}
+
+func PaginationQueryString(parameters PaginationParameters) string {
+
+	q := url.Values{}
+	q.Add("page", fmt.Sprintf("%v", parameters.Page))
+	if parameters.Size > 0 {
+		q.Add("size", fmt.Sprintf("%v", parameters.Size))
+	}
+	if parameters.Sort != "" {
+		q.Add("sort", parameters.Sort)
+	}
+
+	return q.Encode()
+}
+
+type ContentStatus string
+
+const (
+	StatusAny      ContentStatus = ""
+	StatusActive   ContentStatus = "ACTIVE"
+	StatusArchived ContentStatus = "ARCHIVED"
+)
+
+type StatusPaginationParameters struct {
+	Page   int
+	Size   int
+	Sort   string
+	Status ContentStatus
+}
+
+func StatusPaginationQueryString(parameters StatusPaginationParameters) string {
+
+	q := url.Values{}
+	q.Add("page", fmt.Sprintf("%v", parameters.Page))
+	if parameters.Size > 0 {
+		q.Add("size", fmt.Sprintf("%v", parameters.Size))
+	}
+	if parameters.Status != StatusAny {
+		q.Add("status", string(parameters.Status))
+	}
+	if parameters.Sort != "" {
+		q.Add("sort", parameters.Sort)
+	}
+
+	return q.Encode()
+}
+
+type Projection string
+
+const (
+	ProjectionAny   Projection = ""
+	ProjectionBasic Projection = "basic"
+)
+
+type ContentItemPaginationParameters struct {
+	Page                        int
+	Size                        int
+	Sort                        string
+	Status                      ContentStatus
+	FolderId                    string
+	Projection                  Projection
+	ExcludeHierarchicalChildren bool
+}
+
+func ContentItemPaginationQueryString(parameters ContentItemPaginationParameters) string {
+
+	q := url.Values{}
+	q.Add("page", fmt.Sprintf("%v", parameters.Page))
+
+	if parameters.Size > 0 {
+		q.Add("size", fmt.Sprintf("%v", parameters.Size))
+	} else if parameters.Projection != ProjectionBasic {
+		// The default is 20, but if you're json response is too big, the Amplience API will return an error.
+		// Therefore, to be safe we set a default of 6.
+		q.Add("size", "6")
+	}
+	if parameters.Status != StatusAny {
+		q.Add("status", string(parameters.Status))
+	}
+	if parameters.Sort != "" {
+		q.Add("sort", parameters.Sort)
+	}
+	if parameters.ExcludeHierarchicalChildren {
+		q.Add("excludeHierarchicalChildren", "true")
+	}
+	if parameters.FolderId != "" {
+		q.Add("folderId", parameters.FolderId)
+	}
+
+	return strings.Replace(q.Encode(), "%2C", ",", 1)
+}

--- a/content/webhook.go
+++ b/content/webhook.go
@@ -172,9 +172,29 @@ func (client *Client) WebhookDelete(hub_id string, id string) error {
 	return err
 }
 
-func (client *Client) WebhookList(hub_id string) (WebhookResults, error) {
+func (client *Client) WebhookList(hub_id string, parameters PaginationParameters) (WebhookResults, error) {
 	result := WebhookResults{}
-	endpoint := fmt.Sprintf("/hubs/%s/webhooks", hub_id)
+	endpoint := fmt.Sprintf("/hubs/%s/webhooks?%s", hub_id, PaginationQueryString(parameters))
 	err := client.request(http.MethodGet, endpoint, nil, &result)
+	return result, err
+}
+
+func (client *Client) WebhookGetAll(hubID string) ([]Webhook, error) {
+	parameters := PaginationParameters{}
+
+	response, err := client.WebhookList(hubID, parameters)
+
+	var result []Webhook
+	result = append(result, response.Items...)
+
+	for parameters.Page < response.Page.TotalPages-1 {
+		parameters.Page++
+		response, err := client.WebhookList(hubID, parameters)
+		if err != nil {
+			break
+		}
+		result = append(result, response.Items...)
+	}
+
 	return result, err
 }


### PR DESCRIPTION
The List functions only returned the first 20 items. This commit extends those functions for content type, content type schema, content item, content repository, folder, hub, and webhook so that you can add pagination query parameters. Furthermore, for those types an additional function is added to retrieve all items, using the corresponding List function.